### PR TITLE
Pin down input channel instances in the execution lineage

### DIFF
--- a/rheem-basic/src/main/java/org/qcri/rheem/basic/channels/FileChannel.java
+++ b/rheem-basic/src/main/java/org/qcri/rheem/basic/channels/FileChannel.java
@@ -177,6 +177,7 @@ public class FileChannel extends Channel {
         @Override
         public void doDispose() throws RheemException {
             Actions.doSafe(() -> {
+                logger.info("Deleting file channel instances {}.", this.paths);
                 final String path = this.getSinglePath();
                 final Optional<FileSystem> fileSystemOptional = FileSystems.getFileSystem(path);
                 fileSystemOptional.ifPresent(fs -> {

--- a/rheem-core/src/main/java/org/qcri/rheem/core/platform/lineage/LazyExecutionLineageNode.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/platform/lineage/LazyExecutionLineageNode.java
@@ -18,6 +18,12 @@ public abstract class LazyExecutionLineageNode {
      */
     private final Collection<LazyExecutionLineageNode> predecessors = new LinkedList<>();
 
+    /**
+     * Pinned down {@link ChannelInstance}s that must not be disposed before this instance has been marked as
+     * executed.
+     */
+    private final Collection<ChannelInstance> pinnedDownChannelInstances = new LinkedList<>();
+
     private boolean isExecuted = false;
 
     /**
@@ -29,6 +35,15 @@ public abstract class LazyExecutionLineageNode {
         assert !this.predecessors.contains(predecessor) :
                 String.format("Lineage predecessor %s is already present.", predecessor);
         this.predecessors.add(predecessor);
+
+        // TODO: Pinning the input ChannelInstances down like this is not very elegant.
+        // A better solution would be to incorporate all LazyExecutionLineageNodes into the
+        // reference counting scheme. However, this would imply considerable effort to get it right.
+        if (!this.isExecuted && predecessor instanceof ChannelLineageNode) {
+            ChannelInstance channelInstance = ((ChannelLineageNode) predecessor).getChannelInstance();
+            this.pinnedDownChannelInstances.add(channelInstance);
+            channelInstance.noteObtainedReference();
+        }
     }
 
 
@@ -64,6 +79,12 @@ public abstract class LazyExecutionLineageNode {
     protected void markAsExecuted() {
         LoggerFactory.getLogger(this.getClass()).debug("Marking {} as executed.", this);
         this.isExecuted = true;
+
+        // Free pinned down ChannelInstances.
+        for (ChannelInstance channelInstance : this.pinnedDownChannelInstances) {
+            channelInstance.noteDiscardedReference(true);
+        }
+        this.pinnedDownChannelInstances.clear();
     }
 
     public <T> T traverseAndMark(T accumulator, Aggregator<T> aggregator) {

--- a/rheem-core/src/main/java/org/qcri/rheem/core/platform/lineage/LazyExecutionLineageNode.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/platform/lineage/LazyExecutionLineageNode.java
@@ -2,6 +2,7 @@ package org.qcri.rheem.core.platform.lineage;
 
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.util.Tuple;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.Iterator;
@@ -61,6 +62,7 @@ public abstract class LazyExecutionLineageNode {
      * Mark that this instance should not be traversed any more.
      */
     protected void markAsExecuted() {
+        LoggerFactory.getLogger(this.getClass()).debug("Marking {} as executed.", this);
         this.isExecuted = true;
     }
 


### PR DESCRIPTION
This PR offers a hotfix for issue #51 by using Rheem's reference counting facility and execution lineage to pin down input `ChannelInstance`s of lazily executed `ExecutionOperator`s.

In a more principled approach, however, the whole execution lineage could be subject to the reference counting scheme. Also, a test would be nice.