### PR TITLE
Operator filtering

### DIFF
--- a/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/channels/ChannelConversion.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/channels/ChannelConversion.java
@@ -84,6 +84,18 @@ public abstract class ChannelConversion {
                                                                        int numExecutions,
                                                                        OptimizationContext optimizationContext);
 
+    /**
+     * Determine whether this instance is suitable to handle the given conversion.
+     *
+     * @param cardinality         the {@link CardinalityEstimate} of data to be converted
+     * @param numExecutions       expected number of executions of this instance
+     * @param optimizationContext provides a {@link Configuration} and keeps around generated optimization information
+     * @return whether this instance should be filtered
+     */
+    public abstract boolean isFiltered(CardinalityEstimate cardinality,
+                                       int numExecutions,
+                                       OptimizationContext optimizationContext);
+
     @Override
     public String toString() {
         return String.format("%s[%s->%s]",

--- a/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/channels/ChannelConversionGraph.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/channels/ChannelConversionGraph.java
@@ -288,6 +288,11 @@ public class ChannelConversionGraph {
         private Map<ChannelConversion, Double> conversionCostCache = new HashMap<>();
 
         /**
+         * Caches whether {@link ChannelConversion}s should be filtered.
+         */
+        private Map<ChannelConversion, Boolean> conversionFilterCache = new HashMap<>();
+
+        /**
          * Caches the result of {@link #getJunction()}.
          */
         private Junction result = null;
@@ -633,6 +638,12 @@ public class ChannelConversionGraph {
                     continue;
                 }
 
+                // Check if the channelConversion can be filtered.
+                if (successorChannelDescriptors == null && this.isFiltered(channelConversion)) {
+                    logger.info("Filtering conversion {} between {} and {}.", channelConversion, this.sourceOutput, this.destInputs);
+                    continue;
+                }
+
                 if (visitedChannelDescriptors.add(targetChannelDescriptor)) {
                     final Map<Bitmask, Tree> childSolutions = this.enumerate(
                             visitedChannelDescriptors,
@@ -703,7 +714,8 @@ public class ChannelConversionGraph {
                     final Collection<List<Collection<Tree>>> childSolutionSetCombinations =
                             RheemCollections.createPowerList(childSolutionSets, numUnreachedDestinationSets);
                     for (List<Collection<Tree>> childSolutionSetCombination : childSolutionSetCombinations) {
-                        if (childSolutionSetCombination.size() < 2) continue; // only combine when we have more than on child solution
+                        if (childSolutionSetCombination.size() < 2)
+                            continue; // only combine when we have more than on child solution
                         for (List<Tree> solutionCombination : RheemCollections.streamedCrossProduct(childSolutionSetCombination)) {
                             final Tree tree = ChannelConversionGraph.this.mergeTrees(solutionCombination);
                             if (tree != null) {
@@ -755,6 +767,19 @@ public class ChannelConversionGraph {
                         );
                         return costSquasher.applyAsDouble(costEstimate);
                     }
+            );
+        }
+
+        /**
+         * Determine whether the given {@link ChannelConversion} should be filtered.
+         *
+         * @param channelConversion which should be checked for filtering
+         * @return whether to filter the {@link ChannelConversion}
+         */
+        private boolean isFiltered(ChannelConversion channelConversion) {
+            return this.conversionFilterCache.computeIfAbsent(
+                    channelConversion,
+                    key -> key.isFiltered(this.cardinality, this.numExecutions, this.optimizationContextCopy)
             );
         }
 

--- a/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/channels/DefaultChannelConversion.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/channels/DefaultChannelConversion.java
@@ -176,6 +176,19 @@ public class DefaultChannelConversion extends ChannelConversion {
         return operatorContext.getCostEstimate();
     }
 
+    @Override
+    public boolean isFiltered(CardinalityEstimate cardinality, int numExecutions, OptimizationContext optimizationContext) {
+        // Create OperatorContext.
+        final ExecutionOperator executionOperator = this.executionOperatorFactory.apply(null, optimizationContext.getConfiguration());
+        final OptimizationContext.OperatorContext operatorContext = optimizationContext.addOneTimeOperator(executionOperator);
+
+        // Initialize cardinality and number of executions.
+        operatorContext.setNumExecutions(numExecutions);
+        this.setCardinality(operatorContext, cardinality);
+
+        return executionOperator.isFiltered(operatorContext);
+    }
+
     private void setCardinality(OptimizationContext.OperatorContext operatorContext, CardinalityEstimate cardinality) {
         final int numInputs = operatorContext.getOperator().getNumInputs();
         for (int inputIndex = 0; inputIndex < numInputs; inputIndex++) {

--- a/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/enumeration/PlanEnumerator.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/enumeration/PlanEnumerator.java
@@ -426,10 +426,20 @@ public class PlanEnumerator {
                 operatorEnumeration = PlanEnumeration.createSingleton((ExecutionOperator) operator, optimizationContext);
 
                 // Check if the operator is filtered.
-                OptimizationContext.OperatorContext operatorContext = optimizationContext.getOperatorContext(operator);
-                if (operatorContext != null && ((ExecutionOperator) operator).isFiltered(operatorContext)) {
-                    this.logger.info("Filtered {} with context {}.", operator, operatorContext);
-                    operatorEnumeration.getPlanImplementations().clear();
+                // However, we must not filter operators that are pre-settled (i.e., that have been executed already).
+                boolean isPresettled = false;
+                OperatorContainer container = operator.getContainer();
+                if (container instanceof OperatorAlternative.Alternative) {
+                    OperatorAlternative.Alternative alternative = (OperatorAlternative.Alternative) container;
+                    OperatorAlternative operatorAlternative = alternative.getOperatorAlternative();
+                    isPresettled = this.presettledAlternatives.get(operatorAlternative) == alternative;
+                }
+                if (!isPresettled) {
+                    OptimizationContext.OperatorContext operatorContext = optimizationContext.getOperatorContext(operator);
+                    if (operatorContext != null && ((ExecutionOperator) operator).isFiltered(operatorContext)) {
+                        this.logger.info("Filtered {} with context {}.", operator, operatorContext);
+                        operatorEnumeration.getPlanImplementations().clear();
+                    }
                 }
             }
 

--- a/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/enumeration/PlanEnumerator.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/enumeration/PlanEnumerator.java
@@ -424,6 +424,13 @@ public class PlanEnumerator {
             } else {
                 assert operator.isExecutionOperator();
                 operatorEnumeration = PlanEnumeration.createSingleton((ExecutionOperator) operator, optimizationContext);
+
+                // Check if the operator is filtered.
+                OptimizationContext.OperatorContext operatorContext = optimizationContext.getOperatorContext(operator);
+                if (operatorContext != null && ((ExecutionOperator) operator).isFiltered(operatorContext)) {
+                    this.logger.info("Filtered {} with context {}.", operator, operatorContext);
+                    operatorEnumeration.getPlanImplementations().clear();
+                }
             }
 
             if (operatorEnumeration.getPlanImplementations().isEmpty()) {

--- a/rheem-core/src/main/java/org/qcri/rheem/core/plan/rheemplan/ExecutionOperator.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/plan/rheemplan/ExecutionOperator.java
@@ -96,6 +96,13 @@ public interface ExecutionOperator extends ElementaryOperator {
      * @return the limit base key or {@code null}
      */
     default String getLimitBaseKey() {
+        // By default, try to infer the key.
+        String loadProfileEstimatorConfigurationKey = this.getLoadProfileEstimatorConfigurationKey();
+        if (loadProfileEstimatorConfigurationKey != null && loadProfileEstimatorConfigurationKey.endsWith(".load")) {
+            return loadProfileEstimatorConfigurationKey
+                    .substring(0, loadProfileEstimatorConfigurationKey.length() - 5)
+                    .concat(".limit");
+        }
         return null;
     }
 

--- a/rheem-core/src/main/java/org/qcri/rheem/core/plan/rheemplan/ExecutionOperator.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/plan/rheemplan/ExecutionOperator.java
@@ -91,6 +91,21 @@ public interface ExecutionOperator extends ElementaryOperator {
     }
 
     /**
+     * Tells whether this instance should not be executed on the face of the given
+     * {@link OptimizationContext.OperatorContext}. For instance, when this instance
+     * might not be able to handle the amount of data.
+     *
+     * @param operatorContext an {@link OptimizationContext.OperatorContext} within which this instance might be
+     *                        executed
+     * @return whether this instance should <b>not</b> be used for execution
+     */
+    default boolean isFiltered(OptimizationContext.OperatorContext operatorContext) {
+        assert operatorContext.getOperator() == this;
+
+        return false;
+    }
+
+    /**
      * Display the supported {@link Channel}s for a certain {@link InputSlot}.
      *
      * @param index the index of the {@link InputSlot}

--- a/rheem-core/src/main/java/org/qcri/rheem/core/plan/rheemplan/ExecutionOperator.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/plan/rheemplan/ExecutionOperator.java
@@ -2,6 +2,7 @@ package org.qcri.rheem.core.plan.rheemplan;
 
 import org.qcri.rheem.core.api.Configuration;
 import org.qcri.rheem.core.optimizer.OptimizationContext;
+import org.qcri.rheem.core.optimizer.cardinality.CardinalityEstimate;
 import org.qcri.rheem.core.optimizer.costs.LoadProfile;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimators;
@@ -91,6 +92,14 @@ public interface ExecutionOperator extends ElementaryOperator {
     }
 
     /**
+     * Provides a base key for configuring input and output limits.
+     * @return the limit base key or {@code null}
+     */
+    default String getLimitBaseKey() {
+        return null;
+    }
+
+    /**
      * Tells whether this instance should not be executed on the face of the given
      * {@link OptimizationContext.OperatorContext}. For instance, when this instance
      * might not be able to handle the amount of data.
@@ -101,6 +110,34 @@ public interface ExecutionOperator extends ElementaryOperator {
      */
     default boolean isFiltered(OptimizationContext.OperatorContext operatorContext) {
         assert operatorContext.getOperator() == this;
+
+        // By default, we look for configuration keys formed like this:
+        //   <my.operator.limit.key>.<input/output name>
+        // If such a key exists, we compare it to values in the operatorContext.
+        String limitBaseKey = this.getLimitBaseKey();
+        if (limitBaseKey != null) {
+            Configuration configuration = operatorContext.getOptimizationContext().getConfiguration();
+
+            // Check the inputs.
+            for (InputSlot<?> input : this.getAllInputs()) {
+                String key = limitBaseKey + "." + input.getName();
+                long limit = configuration.getLongProperty(key, -1);
+                if (limit >= 0) {
+                    CardinalityEstimate cardinality = operatorContext.getInputCardinality(input.getIndex());
+                    if (cardinality != null && cardinality.getGeometricMeanEstimate() > limit) return true;
+                }
+            }
+
+            // Check the outputs.
+            for (OutputSlot<?> output : this.getAllOutputs()) {
+                String key = limitBaseKey + "." + output.getName();
+                long limit = configuration.getLongProperty(key, -1);
+                if (limit >= 0) {
+                    CardinalityEstimate cardinality = operatorContext.getOutputCardinality(output.getIndex());
+                    if (cardinality != null && cardinality.getGeometricMeanEstimate() > limit) return true;
+                }
+            }
+        }
 
         return false;
     }

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaRandomSampleOperator.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaRandomSampleOperator.java
@@ -107,11 +107,8 @@ public class JavaRandomSampleOperator<Type>
     }
 
     @Override
-    public Optional<LoadProfileEstimator> createLoadProfileEstimator(Configuration configuration) {
-        return Optional.of(new NestableLoadProfileEstimator(
-                new DefaultLoadEstimator(this.getNumInputs(), 1, 0.9d, (inCards, outCards) -> 25 * inCards[0] + 350000),
-                LoadEstimator.createFallback(this.getNumInputs(), 1)
-        ));
+    public Collection<String> getLoadProfileEstimatorConfigurationKeys() {
+        return Collections.singletonList("rheem.java.random-sample.load");
     }
 
     @Override

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaReservoirSampleOperator.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaReservoirSampleOperator.java
@@ -91,11 +91,8 @@ public class JavaReservoirSampleOperator<Type>
     }
 
     @Override
-    public Optional<LoadProfileEstimator> createLoadProfileEstimator(Configuration configuration) {
-        return Optional.of(new NestableLoadProfileEstimator(
-                new DefaultLoadEstimator(this.getNumInputs(), 1, 0.9d, (inCards, outCards) -> 25 * inCards[0] + 350000),
-                LoadEstimator.createFallback(this.getNumInputs(), 1)
-        ));
+    public Collection<String> getLoadProfileEstimatorConfigurationKeys() {
+        return Collections.singleton("rheem.java.reservoir-sample.load");
     }
 
     @Override

--- a/rheem-platforms/rheem-java/src/main/resources/rheem-java-defaults.properties
+++ b/rheem-platforms/rheem-java/src/main/resources/rheem-java-defaults.properties
@@ -38,6 +38,28 @@ rheem.java.flatmap.load = {\
   "p":0.9\
 }
 
+rheem.java.random-sample.load.template = {\
+  "type":"mathex", "in":1, "out":1,\
+  "cpu":"?*in0"\
+}
+rheem.java.random-sample.load = {\
+  "in":1, "out":1,\
+  "cpu":"${25*in0 + 350000}",\
+  "ram":"10000",\
+  "p":0.9\
+}
+
+rheem.java.reservoir-sample.load.template = {\
+  "type":"mathex", "in":1, "out":1,\
+  "cpu":"?*in0"\
+}
+rheem.java.reservoir-sample.load = {\
+  "in":1, "out":1,\
+  "cpu":"${25*in0 + 350000}",\
+  "ram":"10000",\
+  "p":0.9\
+}
+
 rheem.java.mappartitions.load.template = {\
   "type":"mathex", "in":1, "out":1,\
   "cpu":"?*in0"\

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/mapping/SampleMapping.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/mapping/SampleMapping.java
@@ -43,16 +43,16 @@ public class SampleMapping implements Mapping {
         return new ReplacementSubplanFactory.OfSingleOperators<SampleOperator>(
                 (matchedOperator, epoch) -> {
                     switch (matchedOperator.getSampleMethod()) {
-                        case ANY:
                         case RANDOM:
                             return new SparkRandomPartitionSampleOperator<>(matchedOperator);
+                        case ANY:
                         case SHUFFLE_PARTITION_FIRST:
                             return new SparkShufflePartitionSampleOperator<>(matchedOperator);
                         case BERNOULLI:
                             return new SparkBernoulliSampleOperator<>(matchedOperator);
                         default:
                             throw new RheemException(String.format(
-                                    "%s sample method is not yet supported in Java platform.",
+                                    "%s sample method is not yet supported in Sample platform.",
                                     matchedOperator.getSampleMethod()
                             ));
                     }

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkBernoulliSampleOperator.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkBernoulliSampleOperator.java
@@ -78,20 +78,12 @@ public class SparkBernoulliSampleOperator<Type>
         return new SparkBernoulliSampleOperator<>(this);
     }
 
-    @Override
-    public Optional<LoadProfileEstimator> createLoadProfileEstimator(Configuration configuration) {
-        // NB: This was not measured but is guesswork, adapted from SparkFilterOperator.
-        final LoadProfileEstimator mainEstimator = new NestableLoadProfileEstimator(
-                new DefaultLoadEstimator(1, 1, .9d, (inputCards, outputCards) -> 700 * inputCards[0] + 500000000L),
-                new DefaultLoadEstimator(1, 1, .9d, (inputCards, outputCards) -> 10000),
-                new DefaultLoadEstimator(1, 1, .9d, (inputCards, outputCards) -> 0),
-                new DefaultLoadEstimator(1, 1, .9d, (inputCards, outputCards) -> 0),
-                (in, out) -> 0.23d,
-                550
-        );
 
-        return Optional.of(mainEstimator);
+    @Override
+    public String getLoadProfileEstimatorConfigurationKey() {
+        return "rheem.spark.bernoulli-sample.load";
     }
+
 
     @Override
     public List<ChannelDescriptor> getSupportedInputChannels(int index) {

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkRandomPartitionSampleOperator.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkRandomPartitionSampleOperator.java
@@ -176,6 +176,11 @@ public class SparkRandomPartitionSampleOperator<Type>
         return Collections.singletonList(CollectionChannel.DESCRIPTOR);
     }
 
+    public String getLoadProfileEstimatorConfigurationKey() {
+        return "rheem.spark.random-partition-sample.load";
+    }
+
+
     @Override
     public boolean containsAction() {
         return true;

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkShufflePartitionSampleOperator.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkShufflePartitionSampleOperator.java
@@ -129,18 +129,8 @@ public class SparkShufflePartitionSampleOperator<Type>
     }
 
     @Override
-    public Optional<LoadProfileEstimator> createLoadProfileEstimator(Configuration configuration) {
-        // NB: This was not measured but is guesswork, adapted from SparkFilterOperator.
-        final NestableLoadProfileEstimator mainEstimator = new NestableLoadProfileEstimator(
-                new DefaultLoadEstimator(1, 1, .9d, (inputCards, outputCards) -> 700 * inputCards[0] + 500000000L),
-                new DefaultLoadEstimator(1, 1, .9d, (inputCards, outputCards) -> 10000),
-                new DefaultLoadEstimator(1, 1, .9d, (inputCards, outputCards) -> 0),
-                new DefaultLoadEstimator(1, 1, .9d, (inputCards, outputCards) -> 0),
-                (in, out) -> 0.23d,
-                550
-        );
-
-        return Optional.of(mainEstimator);
+    public Collection<String> getLoadProfileEstimatorConfigurationKeys() {
+        return Collections.singleton("rheem.spark.shuffle-partition-sample.load");
     }
 
     @Override

--- a/rheem-platforms/rheem-spark/src/main/resources/rheem-spark-defaults.properties
+++ b/rheem-platforms/rheem-spark/src/main/resources/rheem-spark-defaults.properties
@@ -120,6 +120,21 @@ rheem.spark.random-partition-sample.load = {\
   "ru":"${rheem:logGrowth(0.1, 0.1, 1000000, in0)}"\
 }
 
+rheem.spark.shuffle-partition-sample.load.template = {\
+  "type":"mathex", "in":1, "out":1,\
+  "cpu":"?*in0 + ?"\
+}
+rheem.spark.shuffle-partition-sample.load = {\
+  "in":1, "out":1,\
+  "cpu":"${699*in0 + 500000000}",\
+  "ram":"10000",\
+  "disk":"0",\
+  "net":"0",\
+  "p":0.9,\
+  "overhead":0,\
+  "ru":"${rheem:logGrowth(0.1, 0.1, 1000000, in0)}"\
+}
+
 rheem.spark.reduceby.load.template = {\
   "type":"mathex", "in":1, "out":1,\
   "cpu":"?*in0 + ?"\

--- a/rheem-platforms/rheem-spark/src/main/resources/rheem-spark-defaults.properties
+++ b/rheem-platforms/rheem-spark/src/main/resources/rheem-spark-defaults.properties
@@ -89,6 +89,37 @@ rheem.spark.flatmap.load = {\
   "ru":"${rheem:logGrowth(0.1, 0.1, 1000000, in0)}"\
 }
 
+
+rheem.spark.bernoulli-sample.load.template = {\
+  "type":"mathex", "in":1, "out":1,\
+  "cpu":"?*in0 + ?"\
+}
+rheem.spark.bernoulli-sample.load = {\
+  "in":1, "out":1,\
+  "cpu":"${700*in0 + 500000000}",\
+  "ram":"10000",\
+  "disk":"0",\
+  "net":"0",\
+  "p":0.9,\
+  "overhead":0,\
+  "ru":"${rheem:logGrowth(0.1, 0.1, 1000000, in0)}"\
+}
+
+rheem.spark.random-partition-sample.load.template = {\
+  "type":"mathex", "in":1, "out":1,\
+  "cpu":"?*in0 + ?"\
+}
+rheem.spark.random-partition-sample.load = {\
+  "in":1, "out":1,\
+  "cpu":"${700*in0 + 500000000}",\
+  "ram":"10000",\
+  "disk":"0",\
+  "net":"0",\
+  "p":0.9,\
+  "overhead":0,\
+  "ru":"${rheem:logGrowth(0.1, 0.1, 1000000, in0)}"\
+}
+
 rheem.spark.reduceby.load.template = {\
   "type":"mathex", "in":1, "out":1,\
   "cpu":"?*in0 + ?"\


### PR DESCRIPTION
This PR addresses #66:
- `ExecutionOperator`s and `ChannelConversion`s provide a method `isFiltered` to decide whether they are usable in a certain context.
- By default, `ExecutionOperator`s are associated to a key `***.limit` that tells (if defined) the maximum number of processable data quanta.