### PR TITLE
Add co-group operator

### DIFF
--- a/rheem-basic/src/main/java/org/qcri/rheem/basic/operators/CoGroupOperator.java
+++ b/rheem-basic/src/main/java/org/qcri/rheem/basic/operators/CoGroupOperator.java
@@ -15,7 +15,7 @@ import java.util.Optional;
 
 /**
  * This operator groups both inputs by some key and then matches groups with the same key. If a key appears in only
- * one of the input datasets, then the according group is matched with {@code null}.
+ * one of the input datasets, then the according group is matched with an empty group.
  */
 public class CoGroupOperator<InputType0, InputType1, Key>
         extends BinaryToUnaryOperator<InputType0, InputType1, Tuple2<Iterable<InputType0>, Iterable<InputType1>>> {

--- a/rheem-basic/src/main/java/org/qcri/rheem/basic/operators/CoGroupOperator.java
+++ b/rheem-basic/src/main/java/org/qcri/rheem/basic/operators/CoGroupOperator.java
@@ -1,0 +1,93 @@
+package org.qcri.rheem.basic.operators;
+
+import org.apache.commons.lang3.Validate;
+import org.qcri.rheem.basic.data.Tuple2;
+import org.qcri.rheem.core.api.Configuration;
+import org.qcri.rheem.core.function.FunctionDescriptor;
+import org.qcri.rheem.core.function.TransformationDescriptor;
+import org.qcri.rheem.core.optimizer.cardinality.CardinalityEstimator;
+import org.qcri.rheem.core.optimizer.cardinality.DefaultCardinalityEstimator;
+import org.qcri.rheem.core.plan.rheemplan.BinaryToUnaryOperator;
+import org.qcri.rheem.core.types.DataSetType;
+
+import java.util.Optional;
+
+
+/**
+ * This operator groups both inputs by some key and then matches groups with the same key. If a key appears in only
+ * one of the input datasets, then the according group is matched with {@code null}.
+ */
+public class CoGroupOperator<InputType0, InputType1, Key>
+        extends BinaryToUnaryOperator<InputType0, InputType1, Tuple2<Iterable<InputType0>, Iterable<InputType1>>> {
+
+    private static <InputType0, InputType1> DataSetType<Tuple2<InputType0, InputType1>> createOutputDataSetType() {
+        return DataSetType.createDefaultUnchecked(Tuple2.class);
+    }
+
+    protected final TransformationDescriptor<InputType0, Key> keyDescriptor0;
+
+    protected final TransformationDescriptor<InputType1, Key> keyDescriptor1;
+
+    public CoGroupOperator(FunctionDescriptor.SerializableFunction<InputType0, Key> keyExtractor0,
+                           FunctionDescriptor.SerializableFunction<InputType1, Key> keyExtractor1,
+                           Class<InputType0> input0Class,
+                           Class<InputType1> input1Class,
+                           Class<Key> keyClass) {
+        this(
+                new TransformationDescriptor<>(keyExtractor0, input0Class, keyClass),
+                new TransformationDescriptor<>(keyExtractor1, input1Class, keyClass)
+        );
+    }
+
+    public CoGroupOperator(TransformationDescriptor<InputType0, Key> keyDescriptor0,
+                           TransformationDescriptor<InputType1, Key> keyDescriptor1) {
+        super(DataSetType.createDefault(keyDescriptor0.getInputType()),
+                DataSetType.createDefault(keyDescriptor1.getInputType()),
+                CoGroupOperator.createOutputDataSetType(),
+                true);
+        this.keyDescriptor0 = keyDescriptor0;
+        this.keyDescriptor1 = keyDescriptor1;
+    }
+    public CoGroupOperator(TransformationDescriptor<InputType0, Key> keyDescriptor0,
+                           TransformationDescriptor<InputType1, Key> keyDescriptor1,
+                           DataSetType<InputType0> inputType0,
+                           DataSetType<InputType1> inputType1) {
+        super(inputType0, inputType1, CoGroupOperator.createOutputDataSetType(), true);
+        this.keyDescriptor0 = keyDescriptor0;
+        this.keyDescriptor1 = keyDescriptor1;
+    }
+
+
+    /**
+     * Copies an instance (exclusive of broadcasts).
+     *
+     * @param that that should be copied
+     */
+    public CoGroupOperator(CoGroupOperator<InputType0, InputType1, Key> that) {
+        super(that);
+        this.keyDescriptor0 = that.getKeyDescriptor0();
+        this.keyDescriptor1 = that.getKeyDescriptor1();
+    }
+
+    public TransformationDescriptor<InputType0, Key> getKeyDescriptor0() {
+        return this.keyDescriptor0;
+    }
+
+    public TransformationDescriptor<InputType1, Key> getKeyDescriptor1() {
+        return this.keyDescriptor1;
+    }
+
+
+    @Override
+    public Optional<CardinalityEstimator> createCardinalityEstimator(
+            final int outputIndex,
+            final Configuration configuration) {
+        Validate.inclusiveBetween(0, this.getNumOutputs() - 1, outputIndex);
+        // The current idea: We assume, we have a foreign-key like join
+        // TODO: Find a better estimator.
+        return Optional.of(new DefaultCardinalityEstimator(
+                .5d, 2, this.isSupportingBroadcastInputs(),
+                inputCards -> (long) (0.1 * (inputCards[0] + inputCards[1]))
+        ));
+    }
+}

--- a/rheem-core/src/main/java/org/qcri/rheem/core/util/RheemCollections.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/util/RheemCollections.java
@@ -36,6 +36,20 @@ public class RheemCollections {
     }
 
     /**
+     * Provides the given {@code iterable} as {@link Set}, thereby checking if it is already a {@link Set}.
+     */
+    public static <T> Set<T> asSet(Iterable<T> iterable) {
+        if (iterable instanceof Set<?>) {
+            return (Set<T>) iterable;
+        }
+        Set<T> set = new HashSet<>();
+        for (T t : iterable) {
+            set.add(t);
+        }
+        return set;
+    }
+
+    /**
      * Provides the given {@code values} as {@link Set}.
      */
     public static <T> Set<T> asSet(T... values) {

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/mapping/CoGroupMapping.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/mapping/CoGroupMapping.java
@@ -1,0 +1,40 @@
+package org.qcri.rheem.java.mapping;
+
+import org.qcri.rheem.basic.operators.CoGroupOperator;
+import org.qcri.rheem.basic.operators.JoinOperator;
+import org.qcri.rheem.core.mapping.*;
+import org.qcri.rheem.core.types.DataSetType;
+import org.qcri.rheem.java.operators.JavaCoGroupOperator;
+import org.qcri.rheem.java.operators.JavaJoinOperator;
+import org.qcri.rheem.java.platform.JavaPlatform;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Mapping from {@link JoinOperator} to {@link JavaJoinOperator}.
+ */
+public class CoGroupMapping implements Mapping {
+
+    @Override
+    public Collection<PlanTransformation> getTransformations() {
+        return Collections.singleton(new PlanTransformation(
+                this.createSubplanPattern(),
+                this.createReplacementSubplanFactory(),
+                JavaPlatform.getInstance()
+        ));
+    }
+
+    private SubplanPattern createSubplanPattern() {
+        final OperatorPattern operatorPattern = new OperatorPattern<>(
+                "coGroup", new CoGroupOperator<>(null, null, DataSetType.none(), DataSetType.none()), false
+        );
+        return SubplanPattern.createSingleton(operatorPattern);
+    }
+
+    private ReplacementSubplanFactory createReplacementSubplanFactory() {
+        return new ReplacementSubplanFactory.OfSingleOperators<CoGroupOperator<Object, Object, Object>>(
+                (matchedOperator, epoch) -> new JavaCoGroupOperator<>(matchedOperator).at(epoch)
+        );
+    }
+}

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/mapping/Mappings.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/mapping/Mappings.java
@@ -31,6 +31,7 @@ public class Mappings {
             new IntersectMapping(),
             new CartesianMapping(),
             new JoinMapping(),
+            new CoGroupMapping(),
             new LoopMapping(),
             new DoWhileMapping(),
             new RepeatMapping(),

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaCoGroupOperator.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaCoGroupOperator.java
@@ -1,0 +1,143 @@
+package org.qcri.rheem.java.operators;
+
+import org.qcri.rheem.basic.data.Tuple2;
+import org.qcri.rheem.basic.operators.CoGroupOperator;
+import org.qcri.rheem.core.api.Configuration;
+import org.qcri.rheem.core.function.TransformationDescriptor;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
+import org.qcri.rheem.core.optimizer.cardinality.CardinalityEstimate;
+import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
+import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimators;
+import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
+import org.qcri.rheem.core.platform.ChannelDescriptor;
+import org.qcri.rheem.core.platform.ChannelInstance;
+import org.qcri.rheem.core.platform.lineage.ExecutionLineageNode;
+import org.qcri.rheem.core.types.DataSetType;
+import org.qcri.rheem.core.util.Tuple;
+import org.qcri.rheem.java.channels.CollectionChannel;
+import org.qcri.rheem.java.channels.JavaChannelInstance;
+import org.qcri.rheem.java.channels.StreamChannel;
+import org.qcri.rheem.java.execution.JavaExecutor;
+
+import java.util.*;
+import java.util.function.Function;
+
+/**
+ * Java implementation of the {@link CoGroupOperator}.
+ */
+public class JavaCoGroupOperator<InputType0, InputType1, KeyType>
+        extends CoGroupOperator<InputType0, InputType1, KeyType>
+        implements JavaExecutionOperator {
+
+    /**
+     * Creates a new instance.
+     */
+    public JavaCoGroupOperator(DataSetType<InputType0> inputType0,
+                               DataSetType<InputType1> inputType1,
+                               TransformationDescriptor<InputType0, KeyType> keyDescriptor0,
+                               TransformationDescriptor<InputType1, KeyType> keyDescriptor1) {
+
+        super(keyDescriptor0, keyDescriptor1, inputType0, inputType1);
+    }
+
+    /**
+     * Copies an instance (exclusive of broadcasts).
+     *
+     * @param that that should be copied
+     */
+    public JavaCoGroupOperator(CoGroupOperator<InputType0, InputType1, KeyType> that) {
+        super(that);
+    }
+
+    @Override
+    public Tuple<Collection<ExecutionLineageNode>, Collection<ChannelInstance>> evaluate(
+            ChannelInstance[] inputs,
+            ChannelInstance[] outputs,
+            JavaExecutor javaExecutor,
+            OptimizationContext.OperatorContext operatorContext) {
+        assert inputs.length == this.getNumInputs();
+        assert outputs.length == this.getNumOutputs();
+
+        final Function<InputType0, KeyType> keyExtractor0 = javaExecutor.getCompiler().compile(this.keyDescriptor0);
+        final Function<InputType1, KeyType> keyExtractor1 = javaExecutor.getCompiler().compile(this.keyDescriptor1);
+
+        // Group input 0.
+        final CardinalityEstimate cardinalityEstimate0 = operatorContext.getInputCardinality(0);
+        int expectedNumElements0 = (int) cardinalityEstimate0.getGeometricMeanEstimate();
+        Map<KeyType, Collection<InputType0>> groups0 = new HashMap<>(expectedNumElements0);
+        ((JavaChannelInstance) inputs[0]).<InputType0>provideStream().forEach(dataQuantum0 ->
+                groups0.compute(keyExtractor0.apply(dataQuantum0),
+                        (key, value) -> {
+                            value = value == null ? new LinkedList<>() : value;
+                            value.add(dataQuantum0);
+                            return value;
+                        }
+                )
+        );
+
+        // Group input 1.
+        final CardinalityEstimate cardinalityEstimate1 = operatorContext.getInputCardinality(1);
+        int expectedNumElements1 = (int) cardinalityEstimate1.getGeometricMeanEstimate();
+        Map<KeyType, Collection<InputType1>> groups1 = new HashMap<>(expectedNumElements1);
+        ((JavaChannelInstance) inputs[1]).<InputType1>provideStream().forEach(dataQuantum1 ->
+                groups1.compute(keyExtractor1.apply(dataQuantum1),
+                        (key, value) -> {
+                            value = value == null ? new LinkedList<>() : value;
+                            value.add(dataQuantum1);
+                            return value;
+                        }
+                )
+        );
+
+        // Create the co-groups.
+        Collection<Tuple2<Iterable<InputType0>, Iterable<InputType1>>> coGroups =
+                new ArrayList<>(expectedNumElements0 + expectedNumElements1);
+        for (Map.Entry<KeyType, Collection<InputType0>> entry : groups0.entrySet()) {
+            Collection<InputType0> group0 = entry.getValue();
+            Collection<InputType1> group1 = groups1.remove(entry.getKey());
+            coGroups.add(new Tuple2<>(
+                    group0,
+                    group1 == null ? Collections.emptyList() : group1
+            ));
+        }
+        for (Collection<InputType1> group1 : groups1.values()) {
+            coGroups.add(new Tuple2<>(Collections.emptyList(), group1));
+        }
+        ((CollectionChannel.Instance) outputs[0]).accept(coGroups);
+
+        return ExecutionOperator.modelEagerExecution(inputs, outputs, operatorContext);
+    }
+
+    @Override
+    public Collection<String> getLoadProfileEstimatorConfigurationKeys() {
+        return Collections.singletonList("rheem.java.cogroup.load");
+    }
+
+    @Override
+    public Optional<LoadProfileEstimator> createLoadProfileEstimator(Configuration configuration) {
+        final Optional<LoadProfileEstimator> optEstimator =
+                JavaExecutionOperator.super.createLoadProfileEstimator(configuration);
+        LoadProfileEstimators.nestUdfEstimator(optEstimator, this.keyDescriptor0, configuration);
+        LoadProfileEstimators.nestUdfEstimator(optEstimator, this.keyDescriptor1, configuration);
+        return optEstimator;
+    }
+
+    @Override
+    protected ExecutionOperator createCopy() {
+        return new JavaCoGroupOperator<>(this.getInputType0(), this.getInputType1(),
+                this.getKeyDescriptor0(), this.getKeyDescriptor1());
+    }
+
+    @Override
+    public List<ChannelDescriptor> getSupportedInputChannels(int index) {
+        assert index <= this.getNumInputs() || (index == 0 && this.getNumInputs() == 0);
+        return Arrays.asList(CollectionChannel.DESCRIPTOR, StreamChannel.DESCRIPTOR);
+    }
+
+    @Override
+    public List<ChannelDescriptor> getSupportedOutputChannels(int index) {
+        assert index <= this.getNumOutputs() || (index == 0 && this.getNumOutputs() == 0);
+        return Collections.singletonList(CollectionChannel.DESCRIPTOR);
+    }
+
+}

--- a/rheem-platforms/rheem-java/src/main/resources/rheem-java-defaults.properties
+++ b/rheem-platforms/rheem-java/src/main/resources/rheem-java-defaults.properties
@@ -169,6 +169,17 @@ rheem.java.join.load.probing = {\
   "p":0.9\
 }
 
+rheem.java.cogroup.load.pattern {\
+  "type":"mathex", "in":2, "out":1,\
+  "cpu":"?*(in0 + in1) + ?*out0 + ?"\
+}
+rheem.java.cogroup.load = {\
+  "in":2, "out":1,\
+  "cpu":"${1000*(in0 + in1) + 200*out0 + 1000000}",\
+  "ram":"0",\
+  "p":0.9\
+}
+
 rheem.java.intersect.load.indexing.pattern = {\
   "type":"mathex", "in":2, "out":1,\
   "cpu":"? * min(in0, in1)"\

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/mapping/CoGroupMapping.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/mapping/CoGroupMapping.java
@@ -1,0 +1,40 @@
+package org.qcri.rheem.spark.mapping;
+
+import org.qcri.rheem.basic.operators.CoGroupOperator;
+import org.qcri.rheem.basic.operators.JoinOperator;
+import org.qcri.rheem.core.mapping.*;
+import org.qcri.rheem.core.types.DataSetType;
+import org.qcri.rheem.spark.operators.SparkCoGroupOperator;
+import org.qcri.rheem.spark.operators.SparkJoinOperator;
+import org.qcri.rheem.spark.platform.SparkPlatform;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Mapping from {@link CoGroupOperator} to {@link SparkCoGroupOperator}.
+ */
+public class CoGroupMapping implements Mapping {
+
+    @Override
+    public Collection<PlanTransformation> getTransformations() {
+        return Collections.singleton(new PlanTransformation(
+                this.createSubplanPattern(),
+                this.createReplacementSubplanFactory(),
+                SparkPlatform.getInstance()
+        ));
+    }
+
+    private SubplanPattern createSubplanPattern() {
+        final OperatorPattern operatorPattern = new OperatorPattern<>(
+                "coGroup", new CoGroupOperator<>(null, null, DataSetType.none(), DataSetType.none()), false
+        );
+        return SubplanPattern.createSingleton(operatorPattern);
+    }
+
+    private ReplacementSubplanFactory createReplacementSubplanFactory() {
+        return new ReplacementSubplanFactory.OfSingleOperators<CoGroupOperator<Object, Object, Object>>(
+                (matchedOperator, epoch) -> new SparkCoGroupOperator<>(matchedOperator).at(epoch)
+        );
+    }
+}

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/mapping/Mappings.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/mapping/Mappings.java
@@ -31,6 +31,7 @@ public class Mappings {
             new IntersectMapping(),
             new CartesianMapping(),
             new JoinMapping(),
+            new CoGroupMapping(),
             new LoopMapping(),
             new DoWhileMapping(),
             new RepeatMapping(),

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkCoGroupOperator.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkCoGroupOperator.java
@@ -1,0 +1,143 @@
+package org.qcri.rheem.spark.operators;
+
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.function.Function;
+import org.apache.spark.api.java.function.PairFunction;
+import org.qcri.rheem.basic.data.Tuple2;
+import org.qcri.rheem.basic.operators.CoGroupOperator;
+import org.qcri.rheem.basic.operators.JoinOperator;
+import org.qcri.rheem.core.function.FunctionDescriptor;
+import org.qcri.rheem.core.function.TransformationDescriptor;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
+import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
+import org.qcri.rheem.core.platform.ChannelDescriptor;
+import org.qcri.rheem.core.platform.ChannelInstance;
+import org.qcri.rheem.core.platform.lineage.ExecutionLineageNode;
+import org.qcri.rheem.core.types.DataSetType;
+import org.qcri.rheem.core.util.Tuple;
+import org.qcri.rheem.spark.channels.RddChannel;
+import org.qcri.rheem.spark.compiler.FunctionCompiler;
+import org.qcri.rheem.spark.execution.SparkExecutor;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Spark implementation of the {@link JoinOperator}.
+ */
+public class SparkCoGroupOperator<In0, In1, Key> extends CoGroupOperator<In0, In1, Key> implements SparkExecutionOperator {
+
+    /**
+     * @see CoGroupOperator#CoGroupOperator(FunctionDescriptor.SerializableFunction, FunctionDescriptor.SerializableFunction, Class, Class, Class)
+     */
+    public SparkCoGroupOperator(FunctionDescriptor.SerializableFunction<In0, Key> keyExtractor0,
+                                FunctionDescriptor.SerializableFunction<In1, Key> keyExtractor1,
+                                Class<In0> input0Class,
+                                Class<In1> input1Class,
+                                Class<Key> keyClass) {
+        super(keyExtractor0, keyExtractor1, input0Class, input1Class, keyClass);
+    }
+
+    /**
+     * @see CoGroupOperator#CoGroupOperator(TransformationDescriptor, TransformationDescriptor)
+     */
+    public SparkCoGroupOperator(TransformationDescriptor<In0, Key> keyDescriptor0,
+                                TransformationDescriptor<In1, Key> keyDescriptor1) {
+        super(keyDescriptor0, keyDescriptor1);
+    }
+
+    /**
+     * @see CoGroupOperator#CoGroupOperator(TransformationDescriptor, TransformationDescriptor, DataSetType, DataSetType)
+     */
+    public SparkCoGroupOperator(TransformationDescriptor<In0, Key> keyDescriptor0,
+                                TransformationDescriptor<In1, Key> keyDescriptor1,
+                                DataSetType<In0> inputType0,
+                                DataSetType<In1> inputType1) {
+        super(keyDescriptor0, keyDescriptor1, inputType0, inputType1);
+    }
+
+    /**
+     * @see CoGroupOperator#CoGroupOperator(CoGroupOperator)
+     */
+    public SparkCoGroupOperator(CoGroupOperator<In0, In1, Key> that) {
+        super(that);
+    }
+
+    @Override
+    public Tuple<Collection<ExecutionLineageNode>, Collection<ChannelInstance>> evaluate(
+            ChannelInstance[] inputs,
+            ChannelInstance[] outputs,
+            SparkExecutor sparkExecutor,
+            OptimizationContext.OperatorContext operatorContext) {
+        assert inputs.length == this.getNumInputs();
+        assert outputs.length == this.getNumOutputs();
+
+        final RddChannel.Instance input0 = (RddChannel.Instance) inputs[0];
+        final RddChannel.Instance input1 = (RddChannel.Instance) inputs[1];
+        final RddChannel.Instance output = (RddChannel.Instance) outputs[0];
+
+        final JavaRDD<In0> inputRdd0 = input0.provideRdd();
+        final JavaRDD<In1> inputRdd1 = input1.provideRdd();
+
+        FunctionCompiler compiler = sparkExecutor.getCompiler();
+        final PairFunction<In0, Key, In0> keyExtractor0 = compiler.compileToKeyExtractor(this.keyDescriptor0);
+        final PairFunction<In1, Key, In1> keyExtractor1 = compiler.compileToKeyExtractor(this.keyDescriptor1);
+        JavaPairRDD<Key, In0> pairRdd0 = inputRdd0.mapToPair(keyExtractor0);
+        JavaPairRDD<Key, In1> pairRdd1 = inputRdd1.mapToPair(keyExtractor1);
+
+        final JavaPairRDD<Key, scala.Tuple2<Iterable<In0>, Iterable<In1>>> outputPair =
+                pairRdd0.cogroup(pairRdd1, sparkExecutor.getNumDefaultPartitions());
+        this.name(outputPair);
+
+        // Map the output to what Rheem expects.
+        final JavaRDD<Tuple2<Iterable<In0>, Iterable<In1>>> outputRdd = outputPair.map(new TupleConverter<>());
+        this.name(outputRdd);
+
+        output.accept(outputRdd, sparkExecutor);
+
+        return ExecutionOperator.modelLazyExecution(inputs, outputs, operatorContext);
+    }
+
+    @Override
+    protected ExecutionOperator createCopy() {
+        return new SparkCoGroupOperator<>(this);
+    }
+
+    @Override
+    public String getLoadProfileEstimatorConfigurationKey() {
+        return "rheem.spark.intersect.load";
+    }
+
+    @Override
+    public List<ChannelDescriptor> getSupportedInputChannels(int index) {
+        assert index <= this.getNumInputs() || (index == 0 && this.getNumInputs() == 0);
+        return Arrays.asList(RddChannel.UNCACHED_DESCRIPTOR, RddChannel.CACHED_DESCRIPTOR);
+    }
+
+    @Override
+    public List<ChannelDescriptor> getSupportedOutputChannels(int index) {
+        assert index <= this.getNumOutputs() || (index == 0 && this.getNumOutputs() == 0);
+        return Collections.singletonList(RddChannel.UNCACHED_DESCRIPTOR);
+    }
+
+    @Override
+    public boolean containsAction() {
+        return false;
+    }
+
+    /**
+     * Converts the output of {@link JavaPairRDD#cogroup(JavaPairRDD, int)} to what Rheem expects.
+     * <p><i>TODO: See, if we can somehow dodge all this conversion, which is likely to happen a lot.</i></p>
+     */
+    private static class TupleConverter<InputType0, InputType1, KeyType>
+            implements Function<scala.Tuple2<KeyType, scala.Tuple2<Iterable<InputType0>, Iterable<InputType1>>>, Tuple2<Iterable<InputType0>, Iterable<InputType1>>> {
+
+        @Override
+        public Tuple2<Iterable<InputType0>, Iterable<InputType1>> call(scala.Tuple2<KeyType, scala.Tuple2<Iterable<InputType0>, Iterable<InputType1>>> in) throws Exception {
+            return new Tuple2<>(in._2._1, in._2._2);
+        }
+    }
+}

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkCoGroupOperator.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkCoGroupOperator.java
@@ -108,7 +108,7 @@ public class SparkCoGroupOperator<In0, In1, Key> extends CoGroupOperator<In0, In
 
     @Override
     public String getLoadProfileEstimatorConfigurationKey() {
-        return "rheem.spark.intersect.load";
+        return "rheem.spark.cogroup.load";
     }
 
     @Override

--- a/rheem-platforms/rheem-spark/src/main/resources/rheem-spark-defaults.properties
+++ b/rheem-platforms/rheem-spark/src/main/resources/rheem-spark-defaults.properties
@@ -255,6 +255,21 @@ rheem.spark.join.load = {\
   "ru":"${rheem:logGrowth(0.1, 0.1, 1000000, in0 + in1)}"\
 }
 
+rheem.spark.cogroup.load.template = {\
+  "type":"mathex", "in":2, "out":1,\
+  "cpu":"?*(in0 + in1) + ?*out0 + ?"\
+}
+rheem.spark.cogroup.load = {\
+  "in":2, "out":1,\
+  "cpu":"${1700 * (in0 + in1 + out0) + 56789}",\
+  "ram":"0",\
+  "disk":"${20 * in0}",\
+  "net":"${20 * (in0 + in1 + out0) + 430000}",\
+  "p":0.9,\
+  "overhead":0,\
+  "ru":"${rheem:logGrowth(0.1, 0.1, 1000000, in0 + in1)}"\
+}
+
 rheem.spark.intersect.load.template = {\
   "type":"mathex", "in":2, "out":1,\
   "cpu":"?*(in0 + in1) + ?*out0 + ?"\

--- a/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkCoGroupOperatorTest.java
+++ b/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkCoGroupOperatorTest.java
@@ -1,0 +1,104 @@
+package org.qcri.rheem.spark.operators;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.qcri.rheem.basic.data.Tuple2;
+import org.qcri.rheem.basic.function.ProjectionDescriptor;
+import org.qcri.rheem.core.platform.ChannelInstance;
+import org.qcri.rheem.core.types.DataSetType;
+import org.qcri.rheem.core.types.DataUnitType;
+import org.qcri.rheem.core.util.RheemCollections;
+import org.qcri.rheem.core.util.Tuple;
+import org.qcri.rheem.spark.channels.RddChannel;
+
+import java.util.*;
+
+/**
+ * Test suite for {@link SparkJoinOperator}.
+ */
+public class SparkCoGroupOperatorTest extends SparkOperatorTestBase {
+
+    @Test
+    public void testExecution() {
+        // Prepare test data.
+        RddChannel.Instance input0 = this.createRddChannelInstance(Arrays.asList(
+                new Tuple2<>(1, "b"), new Tuple2<>(1, "c"), new Tuple2<>(2, "d"), new Tuple2<>(3, "e")));
+        RddChannel.Instance input1 = this.createRddChannelInstance(Arrays.asList(
+                new Tuple2<>("x", 1), new Tuple2<>("y", 1), new Tuple2<>("z", 2), new Tuple2<>("w", 4)));
+        RddChannel.Instance output = this.createRddChannelInstance();
+
+        // Build the Cartesian operator.
+        SparkCoGroupOperator<Tuple2, Tuple2, Integer> coGroup =
+                new SparkCoGroupOperator<>(
+                        new ProjectionDescriptor<>(
+                                DataUnitType.createBasicUnchecked(Tuple2.class),
+                                DataUnitType.createBasic(Integer.class),
+                                "field0"),
+                        new ProjectionDescriptor<>(
+                                DataUnitType.createBasicUnchecked(Tuple2.class),
+                                DataUnitType.createBasic(Integer.class),
+                                "field1"),
+                        DataSetType.createDefaultUnchecked(Tuple2.class),
+                        DataSetType.createDefaultUnchecked(Tuple2.class)
+                );
+
+        // Set up the ChannelInstances.
+        final ChannelInstance[] inputs = new ChannelInstance[]{input0, input1};
+        final ChannelInstance[] outputs = new ChannelInstance[]{output};
+
+        // Execute.
+        this.evaluate(coGroup, inputs, outputs);
+
+        // Verify the outcome.
+        final List<Tuple2<Iterable<Tuple2<Integer, String>>, Iterable<Tuple2<String, Integer>>>> result =
+                output.<Tuple2<Iterable<Tuple2<Integer, String>>, Iterable<Tuple2<String, Integer>>>>provideRdd().collect();
+        Collection<Tuple<Collection<Tuple2<Integer, String>>, Collection<Tuple2<String, Integer>>>> expectedGroups =
+                new ArrayList<>(Arrays.asList(
+                        new Tuple<Collection<Tuple2<Integer, String>>, Collection<Tuple2<String, Integer>>>(
+                                Arrays.asList(new Tuple2<>(1, "b"), new Tuple2<>(1, "c")),
+                                Arrays.asList(new Tuple2<>("x", 1), new Tuple2<>("y", 1))
+                        ),
+                        new Tuple<Collection<Tuple2<Integer, String>>, Collection<Tuple2<String, Integer>>>(
+                                Collections.singletonList(new Tuple2<>(2, "d")),
+                                Collections.singletonList(new Tuple2<>("z", 2))
+                        ), new Tuple<Collection<Tuple2<Integer, String>>, Collection<Tuple2<String, Integer>>>(
+                                Collections.singletonList(new Tuple2<>(3, "e")),
+                                Collections.emptyList()
+                        ),
+                        new Tuple<Collection<Tuple2<Integer, String>>, Collection<Tuple2<String, Integer>>>(
+                                Collections.emptyList(),
+                                Collections.singletonList(new Tuple2<>("w", 4))
+                        )
+                ));
+
+        ResultLoop:
+        for (Tuple2<Iterable<Tuple2<Integer, String>>, Iterable<Tuple2<String, Integer>>> resultCoGroup : result) {
+            for (Iterator<Tuple<Collection<Tuple2<Integer, String>>, Collection<Tuple2<String, Integer>>>> i = expectedGroups.iterator();
+                 i.hasNext(); ) {
+                Tuple<Collection<Tuple2<Integer, String>>, Collection<Tuple2<String, Integer>>> expectedGroup = i.next();
+                if (this.compare(expectedGroup, resultCoGroup)) {
+                    i.remove();
+                    continue ResultLoop;
+                }
+            }
+            Assert.fail(String.format("Unexpected group: %s", resultCoGroup));
+        }
+        Assert.assertTrue(
+                String.format("Missing groups: %s", expectedGroups),
+                expectedGroups.isEmpty()
+        );
+    }
+
+    private boolean compare(Tuple<Collection<Tuple2<Integer, String>>, Collection<Tuple2<String, Integer>>> expected,
+                            Tuple2<Iterable<Tuple2<Integer, String>>, Iterable<Tuple2<String, Integer>>> actual) {
+        return this.compareGroup(expected.field0, actual.field0) && this.compareGroup(expected.field1, actual.field1);
+    }
+
+    private <T> boolean compareGroup(Collection<T> expected, Iterable<T> actual) {
+        if (expected == null) return actual == null;
+        if (actual == null) return false;
+
+        return RheemCollections.asSet(expected).equals(RheemCollections.asSet(actual));
+    }
+
+}


### PR DESCRIPTION
This PR addresses #2:
- Add a platform-agnostic `CoGroupOperator`.
- Add and map `JavaCoGroupOperator` and `SparkCoGroupOperator`.
- Reflect the new functionality in both the Scala and Java API.