### PR TITLE
Tag artifacts with Scala version

### DIFF
--- a/bin/change-scala-version.sh
+++ b/bin/change-scala-version.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+if [ $# -eq 0 ]; then
+	>&2 echo "No parameters given."
+	echo "This script changes the Scala version used in this project."
+	echo "Usage: $0 <new Scala version (e.g., 2.12.4)>"
+	exit 1
+fi
+
+basedir="$(cd "$(dirname "$0")/.."; pwd)"
+
+# Detect the old versions.
+old_minor="$(grep -o "<scala.version>.*</scala.version>" "$basedir/pom.xml" | sed 's/^<scala.version>\(.*\)<\/scala.version>$/\1/')"
+old_major="$(grep -o "<scala.compat.version>.*</scala.compat.version>" "$basedir/pom.xml" | sed 's/^<scala.compat.version>\(.*\)<\/scala.compat.version>$/\1/')"
+echo "Old Scala version: $old_major/$old_minor"
+
+new_minor="$1"
+new_major="$(echo "$new_minor" | awk -F'.' '{printf("%s.%s", $1, $2);}')"
+
+echo "New Scala version: $new_major/$new_minor"
+
+case "$(uname -s)" in
+	Darwin)
+		sed_opts=("-i" ".bak")
+		;;
+	Linux)
+		sed_opts=("-i.bak")
+		;;
+	*)
+		echo "Unknown OS... configure this script to get the sed command right."
+		exit 2
+esac
+
+echo "Applying changes..."
+find "$basedir" -name pom.xml -a -type f -exec \
+	sed "${sed_opts[@]}" -e "s/<scala.version>$old_minor<\/scala.version>/<scala.version>$new_minor<\/scala.version>/" \
+	-e "s/<scala.compat.version>$old_major<\/scala.compat.version>/<scala.compat.version>$new_major<\/scala.compat.version>/" \
+	-e "s/_$old_major<\//_$new_major<\//" \
+	{} ';'

--- a/bin/contains-scala-dependencies.sh
+++ b/bin/contains-scala-dependencies.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+verbose=false
+
+if [ $# -ne 1 ]; then
+	>&2 echo "$0 expects exactly one input path."
+	exit 1
+fi
+
+if [ ! -f "$1" ] || [[ ! "$1" =~ /pom.xml$ ]]; then
+	>&2 echo "$1 is not a pom.xml."
+	exit 1
+fi
+
+scaladeps=$(cd "$(dirname "$1")" && mvn -o dependency:list | grep -e "_2.[891][0-9]*:" | wc -l | tr -cd "[0-9]")
+echo "$1 has $scaladeps Scala dependencies."
+[ "$verbose" == true ] && [ $scaladeps -gt 0 ] && (cd "$(dirname "$1")" && mvn -o dependency:list | grep -e "_2.[891][0-9]*:" | awk '{printf("- %s\n", $0)}')

--- a/bin/detect-scala-dependent-projects.sh
+++ b/bin/detect-scala-dependent-projects.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo "This scripts heuristically determines all (sub-)projects that seem to depend on Scala-dependencies and should therefore be sensitive w.r.t. the Scala version."
+
+basedir="$(cd "$(dirname "$0")/.."; pwd)"
+find "$basedir" -name pom.xml -a -type f -exec "$basedir/bin/contains-scala-dependencies.sh" "{}" \;

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.qcri.rheem</groupId>
     <artifactId>rheem</artifactId>
     <packaging>pom</packaging>
-    <version>0.2.2-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
 
     <name>Rheem</name>
     <description>Rheem is a tool to build platform-agnostic data processing apps and have them both optimized for and

--- a/rheem-api/pom.xml
+++ b/rheem-api/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <artifactId>rheem</artifactId>
         <groupId>org.qcri.rheem</groupId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>rheem-api</artifactId>
+    <artifactId>rheem-api_2.11</artifactId>
 
     <build>
         <plugins>
@@ -43,35 +43,35 @@
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-core</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-basic</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-java</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
-            <artifactId>rheem-spark</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <artifactId>rheem-spark_2.11</artifactId>
+            <version>0.3.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-sqlite3</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-jdbc-template</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
@@ -80,8 +80,8 @@
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
-            <artifactId>rheem-graphchi</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <artifactId>rheem-graphchi_2.11</artifactId>
+            <version>0.3.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/rheem-basic/pom.xml
+++ b/rheem-basic/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>rheem</artifactId>
         <groupId>org.qcri.rheem</groupId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-core</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/rheem-core/pom.xml
+++ b/rheem-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>rheem</artifactId>
         <groupId>org.qcri.rheem</groupId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rheem-distro/pom.xml
+++ b/rheem-distro/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <artifactId>rheem</artifactId>
         <groupId>org.qcri.rheem</groupId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>rheem-distro</artifactId>
+    <artifactId>rheem-distro_2.11</artifactId>
 
     <build>
         <plugins>
@@ -37,52 +37,52 @@
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-core</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-basic</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-java</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
-            <artifactId>rheem-spark</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <artifactId>rheem-spark_2.11</artifactId>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
-            <artifactId>rheem-graphchi</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <artifactId>rheem-graphchi_2.11</artifactId>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-profiler</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-jdbc-template</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-sqlite3</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-postgres</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
-            <artifactId>rheem-api</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <artifactId>rheem-api_2.11</artifactId>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/rheem-extensions/pom.xml
+++ b/rheem-extensions/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>rheem</artifactId>
         <groupId>org.qcri.rheem</groupId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rheem-extensions/rheem-iejoin/pom.xml
+++ b/rheem-extensions/rheem-iejoin/pom.xml
@@ -5,33 +5,33 @@
     <parent>
         <artifactId>rheem-extensions</artifactId>
         <groupId>org.qcri.rheem</groupId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>rheem-iejoin</artifactId>
+    <artifactId>rheem-iejoin_2.11</artifactId>
     <packaging>jar</packaging>
 
     <dependencies>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-core</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-basic</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-java</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
-            <artifactId>rheem-spark</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <artifactId>rheem-spark_2.11</artifactId>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>

--- a/rheem-platforms/pom.xml
+++ b/rheem-platforms/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>rheem</artifactId>
         <groupId>org.qcri.rheem</groupId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rheem-platforms/rheem-graphchi/pom.xml
+++ b/rheem-platforms/rheem-graphchi/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <artifactId>rheem-platforms</artifactId>
         <groupId>org.qcri.rheem</groupId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>rheem-graphchi</artifactId>
+    <artifactId>rheem-graphchi_2.11</artifactId>
 
     <dependencies>
         <dependency>
@@ -20,17 +20,17 @@
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-core</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-basic</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-java</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/rheem-platforms/rheem-java/pom.xml
+++ b/rheem-platforms/rheem-java/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>rheem-platforms</artifactId>
         <groupId>org.qcri.rheem</groupId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -16,12 +16,12 @@
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-core</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-basic</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/rheem-platforms/rheem-jdbc-template/pom.xml
+++ b/rheem-platforms/rheem-jdbc-template/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>rheem-platforms</artifactId>
         <groupId>org.qcri.rheem</groupId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -14,17 +14,17 @@
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-core</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-basic</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-java</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.hsqldb</groupId>

--- a/rheem-platforms/rheem-postgres/pom.xml
+++ b/rheem-platforms/rheem-postgres/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>rheem-platforms</artifactId>
         <groupId>org.qcri.rheem</groupId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -19,12 +19,12 @@
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-basic</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-jdbc-template</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/rheem-platforms/rheem-spark/pom.xml
+++ b/rheem-platforms/rheem-spark/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <artifactId>rheem-platforms</artifactId>
         <groupId>org.qcri.rheem</groupId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>rheem-spark</artifactId>
+    <artifactId>rheem-spark_2.11</artifactId>
 
     <packaging>jar</packaging>
 
@@ -32,18 +32,18 @@
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-core</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-basic</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <!-- rheem-java is required to allow for direct communication between spark and java -->
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-java</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>

--- a/rheem-platforms/rheem-sqlite3/pom.xml
+++ b/rheem-platforms/rheem-sqlite3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>rheem-platforms</artifactId>
         <groupId>org.qcri.rheem</groupId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,17 +15,17 @@
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-core</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-basic</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-jdbc-template</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.xerial</groupId>

--- a/rheem-profiler/pom.xml
+++ b/rheem-profiler/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <artifactId>rheem</artifactId>
         <groupId>org.qcri.rheem</groupId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>rheem-profiler</artifactId>
+    <artifactId>rheem-profiler_2.11</artifactId>
 
     <dependencies>
         <dependency>
@@ -19,28 +19,28 @@
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
-            <artifactId>rheem-spark</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <artifactId>rheem-spark_2.11</artifactId>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-java</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
-            <artifactId>rheem-graphchi</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <artifactId>rheem-graphchi_2.11</artifactId>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-postgres</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-sqlite3</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>

--- a/rheem-tests/pom.xml
+++ b/rheem-tests/pom.xml
@@ -5,52 +5,52 @@
     <parent>
         <artifactId>rheem</artifactId>
         <groupId>org.qcri.rheem</groupId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>rheem-tests</artifactId>
+    <artifactId>rheem-tests_2.11</artifactId>
     <dependencies>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-core</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-basic</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-java</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
-            <artifactId>rheem-spark</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <artifactId>rheem-spark_2.11</artifactId>
+            <version>0.3.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-sqlite3</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-postgres</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>0.3.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
-            <artifactId>rheem-graphchi</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <artifactId>rheem-graphchi_2.11</artifactId>
+            <version>0.3.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -60,14 +60,14 @@
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
-            <artifactId>rheem-api</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <artifactId>rheem-api_2.11</artifactId>
+            <version>0.3.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
-            <artifactId>rheem-iejoin</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <artifactId>rheem-iejoin_2.11</artifactId>
+            <version>0.3.0-SNAPSHOT</version>
         </dependency>
 
         <!-- Spark is a provided dependency and thus not transitively injected via rheem-spark. -->


### PR DESCRIPTION
This PR addresses #32:
- any module that depends on a specific Scala version (transitively) gets a tag
- helper scripts detect those modules and also allow to change the Scala version throughout the project
- this is the last scheduled change before the next release, so the project version is set to `0.3.0-SNAPSHOT`