### PR TITLE
Rheem spark2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,9 +10,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <scala.version>2.11.8</scala.version>
         <scala.compat.version>2.11</scala.compat.version>
-        <spark.version>1.6.0</spark.version>
+        <spark.version>2.1.0</spark.version>
         <!-- This Hadoop version is enforced by Spark in the version that is deployed in the Maven repository via code signing. -->
-        <hadoop.version>2.2.0</hadoop.version>
+        <hadoop.version>2.6.0</hadoop.version>
         <graphchi.version>0.2.2</graphchi.version>
         <antlr.version>4.5.3</antlr.version>
         <external.platforms.scope>provided</external.platforms.scope>

--- a/pom.xml
+++ b/pom.xml
@@ -136,9 +136,9 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>com.atlassian.maven.plugins</groupId>
+                    <groupId>org.openclover</groupId>
                     <artifactId>clover-maven-plugin</artifactId>
-                    <version>4.1.2</version>
+                    <version>4.2.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-assembly-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.qcri.rheem</groupId>
     <artifactId>rheem</artifactId>
     <packaging>pom</packaging>
-    <version>0.3.1-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
 
     <name>Rheem</name>
     <description>Rheem is a tool to build platform-agnostic data processing apps and have them both optimized for and

--- a/rheem-api/pom.xml
+++ b/rheem-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>rheem</artifactId>
         <groupId>org.qcri.rheem</groupId>
-        <version>0.3.1-SNAPSHOT</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -43,35 +43,35 @@
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-core</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-basic</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-java</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-spark_2.11</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-sqlite3</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-jdbc-template</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-graphchi_2.11</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/rheem-basic/pom.xml
+++ b/rheem-basic/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>rheem</artifactId>
         <groupId>org.qcri.rheem</groupId>
-        <version>0.3.1-SNAPSHOT</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-core</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/rheem-core/pom.xml
+++ b/rheem-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>rheem</artifactId>
         <groupId>org.qcri.rheem</groupId>
-        <version>0.3.1-SNAPSHOT</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rheem-distro/pom.xml
+++ b/rheem-distro/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>rheem</artifactId>
         <groupId>org.qcri.rheem</groupId>
-        <version>0.3.1-SNAPSHOT</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -37,52 +37,52 @@
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-core</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-basic</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-java</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-spark_2.11</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-graphchi_2.11</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-profiler_2.11</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-jdbc-template</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-sqlite3</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-postgres</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-api_2.11</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/rheem-extensions/pom.xml
+++ b/rheem-extensions/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>rheem</artifactId>
         <groupId>org.qcri.rheem</groupId>
-        <version>0.3.1-SNAPSHOT</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rheem-extensions/rheem-iejoin/pom.xml
+++ b/rheem-extensions/rheem-iejoin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>rheem-extensions</artifactId>
         <groupId>org.qcri.rheem</groupId>
-        <version>0.3.1-SNAPSHOT</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -16,22 +16,22 @@
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-core</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-basic</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-java</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-spark_2.11</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>

--- a/rheem-extensions/rheem-iejoin/src/main/java/org/qcri/rheem/iejoin/operators/SparkIEJoinOperator.java
+++ b/rheem-extensions/rheem-iejoin/src/main/java/org/qcri/rheem/iejoin/operators/SparkIEJoinOperator.java
@@ -90,7 +90,7 @@ public class SparkIEJoinOperator<Type0 extends Comparable<Type0>, Type1 extends 
                         i++;
                     }
                     out.add(i);
-                    return out;
+                    return out.iterator();
                 }
                 , true).reduce((input1, input2) -> Math.max(input1, input2));
 
@@ -103,7 +103,7 @@ public class SparkIEJoinOperator<Type0 extends Comparable<Type0>, Type1 extends 
                         i++;
                     }
                     out.add(i);
-                    return out;
+                    return out.iterator();
                 }
                 , true).reduce((input1, input2) -> Math.max(input1, input2));
 

--- a/rheem-extensions/rheem-iejoin/src/main/java/org/qcri/rheem/iejoin/operators/SparkIESelfJoinOperator.java
+++ b/rheem-extensions/rheem-iejoin/src/main/java/org/qcri/rheem/iejoin/operators/SparkIESelfJoinOperator.java
@@ -80,7 +80,7 @@ public class SparkIESelfJoinOperator<Type0 extends Comparable<Type0>, Type1 exte
                         i++;
                     }
                     out.add(i);
-                    return out;
+                    return out.iterator();
                 }
                 , true).reduce((input1, input2) -> Math.max(input1, input2));
 

--- a/rheem-extensions/rheem-iejoin/src/main/java/org/qcri/rheem/iejoin/operators/spark_helpers/BitSetJoin.java
+++ b/rheem-extensions/rheem-iejoin/src/main/java/org/qcri/rheem/iejoin/operators/spark_helpers/BitSetJoin.java
@@ -7,6 +7,7 @@ import scala.Tuple2;
 
 import java.util.ArrayList;
 import java.util.BitSet;
+import java.util.Iterator;
 
 /**
  * Created by khayyzy on 5/28/16.
@@ -83,7 +84,7 @@ public class BitSetJoin<Type0 extends Comparable<Type0>, Type1 extends Comparabl
         return result;
     }
 
-    public Iterable<scala.Tuple2<Long, Long>> call(
+    public Iterator<Tuple2<Long, Long>> call(
             Tuple2<List2AttributesObjectSkinny<Type0, Type1>, List2AttributesObjectSkinny<Type0, Type1>> arg0)
             throws Exception {
         // ArrayList<Tuple2<Long, Long>> output = new ArrayList<Tuple2<Long,
@@ -105,7 +106,7 @@ public class BitSetJoin<Type0 extends Comparable<Type0>, Type1 extends Comparabl
 
             ArrayList<Tuple2<Long, Long>> wilResult = getViolationsSelf(lst1a,
                     permutationArray);
-            return wilResult;
+            return wilResult.iterator();
         } else {
 
             Data[] lst1a = arg0._1().getList1();
@@ -130,7 +131,7 @@ public class BitSetJoin<Type0 extends Comparable<Type0>, Type1 extends Comparabl
             ArrayList<Tuple2<Long, Long>> wilResult = getViolationsNonSelf(
                     list1, permutationArray);
 
-            return wilResult;
+            return wilResult.iterator();
         }
         // return output;
 

--- a/rheem-platforms/pom.xml
+++ b/rheem-platforms/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>rheem</artifactId>
         <groupId>org.qcri.rheem</groupId>
-        <version>0.3.1-SNAPSHOT</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rheem-platforms/rheem-graphchi/pom.xml
+++ b/rheem-platforms/rheem-graphchi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>rheem-platforms</artifactId>
         <groupId>org.qcri.rheem</groupId>
-        <version>0.3.1-SNAPSHOT</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -20,17 +20,17 @@
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-core</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-basic</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-java</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/rheem-platforms/rheem-java/pom.xml
+++ b/rheem-platforms/rheem-java/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>rheem-platforms</artifactId>
         <groupId>org.qcri.rheem</groupId>
-        <version>0.3.1-SNAPSHOT</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -16,12 +16,12 @@
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-core</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-basic</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/rheem-platforms/rheem-jdbc-template/pom.xml
+++ b/rheem-platforms/rheem-jdbc-template/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>rheem-platforms</artifactId>
         <groupId>org.qcri.rheem</groupId>
-        <version>0.3.1-SNAPSHOT</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -14,17 +14,17 @@
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-core</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-basic</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-java</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.hsqldb</groupId>

--- a/rheem-platforms/rheem-postgres/pom.xml
+++ b/rheem-platforms/rheem-postgres/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>rheem-platforms</artifactId>
         <groupId>org.qcri.rheem</groupId>
-        <version>0.3.1-SNAPSHOT</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -19,12 +19,12 @@
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-basic</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-jdbc-template</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/rheem-platforms/rheem-spark/pom.xml
+++ b/rheem-platforms/rheem-spark/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>rheem-platforms</artifactId>
         <groupId>org.qcri.rheem</groupId>
-        <version>0.3.1-SNAPSHOT</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -32,18 +32,18 @@
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-core</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-basic</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <!-- rheem-java is required to allow for direct communication between spark and java -->
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-java</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/compiler/ExtendedFlatMapFunctionAdapter.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/compiler/ExtendedFlatMapFunctionAdapter.java
@@ -6,6 +6,8 @@ import org.qcri.rheem.core.function.ExecutionContext;
 import org.qcri.rheem.core.function.FunctionDescriptor;
 import org.qcri.rheem.spark.execution.SparkExecutionContext;
 
+import java.util.Iterator;
+
 /**
  * Implements a {@link FlatMapFunction} that calls {@link org.qcri.rheem.core.function.ExtendedFunction#open(ExecutionContext)}
  * of its implementation before delegating the very first {@link Function#call(Object)}.
@@ -25,13 +27,13 @@ public class ExtendedFlatMapFunctionAdapter<InputType, OutputType> implements Fl
     }
 
     @Override
-    public Iterable<OutputType> call(InputType v1) throws Exception {
+    public Iterator<OutputType> call(InputType v1) throws Exception {
         if (this.isFirstRun) {
             this.impl.open(this.executionContext);
             this.isFirstRun = false;
         }
 
-        return this.impl.apply(v1);
+        return this.impl.apply(v1).iterator();
     }
 
 }

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/compiler/ExtendedMapPartitionsFunctionAdapter.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/compiler/ExtendedMapPartitionsFunctionAdapter.java
@@ -28,7 +28,7 @@ public class ExtendedMapPartitionsFunctionAdapter<InputType, OutputType>
     }
 
     @Override
-    public Iterable<OutputType> call(Iterator<InputType> it) throws Exception {
+    public Iterator<OutputType> call(Iterator<InputType> it) throws Exception {
         this.impl.open(executionContext);
         List<OutputType> out = new ArrayList<>();
         while (it.hasNext()) {
@@ -37,6 +37,6 @@ public class ExtendedMapPartitionsFunctionAdapter<InputType, OutputType>
                 out.add(dataQuantum);
             }
         }
-        return out;
+        return out.iterator();
     }
 }

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/compiler/FlatMapFunctionAdapter.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/compiler/FlatMapFunctionAdapter.java
@@ -2,6 +2,8 @@ package org.qcri.rheem.spark.compiler;
 
 import org.apache.spark.api.java.function.FlatMapFunction;
 
+import java.util.Iterator;
+
 /**
  * Wraps a {@link java.util.function.Function} as a {@link FlatMapFunction}.
  */
@@ -14,7 +16,7 @@ public class FlatMapFunctionAdapter<InputType, OutputType> implements FlatMapFun
     }
 
     @Override
-    public Iterable<OutputType> call(InputType dataQuantum) throws Exception {
-        return this.function.apply(dataQuantum);
+    public Iterator<OutputType> call(InputType dataQuantum) throws Exception {
+        return this.function.apply(dataQuantum).iterator();
     }
 }

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/compiler/MapPartitionsFunctionAdapter.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/compiler/MapPartitionsFunctionAdapter.java
@@ -20,7 +20,7 @@ public class MapPartitionsFunctionAdapter<InputType, OutputType> implements Flat
     }
 
     @Override
-    public Iterable<OutputType> call(Iterator<InputType> it) throws Exception {
+    public Iterator<OutputType> call(Iterator<InputType> it) throws Exception {
         List<OutputType> out = new ArrayList<>();
         while (it.hasNext()) {
             final Iterable<OutputType> mappedPartition = this.function.apply(Iterators.wrapWithIterable(it));
@@ -28,6 +28,6 @@ public class MapPartitionsFunctionAdapter<InputType, OutputType> implements Flat
                 out.add(dataQuantum);
             }
         }
-        return out;
+        return out.iterator();
     }
 }

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkGlobalMaterializedGroupOperator.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkGlobalMaterializedGroupOperator.java
@@ -61,7 +61,7 @@ public class SparkGlobalMaterializedGroupOperator<Type>
                     while (partitionIterator.hasNext()) {
                         dataUnitGroup.add(partitionIterator.next());
                     }
-                    return Collections.singleton(dataUnitGroup);
+                    return (Iterator)Collections.singleton(dataUnitGroup).iterator();
                 });
         this.name(outputRdd);
 

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkRandomPartitionSampleOperator.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkRandomPartitionSampleOperator.java
@@ -100,7 +100,7 @@ public class SparkRandomPartitionSampleOperator<Type>
             Object samples = sparkContext.runJob(inputRdd.rdd(),
                     new PartitionSampleFunction(tid, ((tid + sampleSize))),
                     (scala.collection.Seq) JavaConversions.asScalaBuffer(partitions),
-                    true, scala.reflect.ClassTag$.MODULE$.apply(List.class));
+                    scala.reflect.ClassTag$.MODULE$.apply(List.class));
             result = ((List<Type>[]) samples)[0];
         } else {
             HashMap<Integer, ArrayList<Integer>> map = new HashMap<>(); //list should be ordered..
@@ -134,7 +134,7 @@ public class SparkRandomPartitionSampleOperator<Type>
                         sparkContext.runJob(inputRdd.rdd(),
                                 new PartitionSampleListFunction(list),
                                 (scala.collection.Seq) JavaConversions.asScalaBuffer(partitions),
-                                true, scala.reflect.ClassTag$.MODULE$.apply(List.class))));
+                                scala.reflect.ClassTag$.MODULE$.apply(List.class))));
             }
 
             for (int i = 0; i < map.size(); i++)

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkShufflePartitionSampleOperator.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkShufflePartitionSampleOperator.java
@@ -106,7 +106,7 @@ public class SparkShufflePartitionSampleOperator<Type>
             //read sequentially from partitionID
             Object samples = sparkContext.runJob(shuffledRDD.rdd(),
                     new TakeSampleFunction(tupleID, tupleID + sampleSize),
-                    (scala.collection.Seq) JavaConversions.asScalaBuffer(pars), true, scala.reflect.ClassTag$.MODULE$.apply(List.class));
+                    (scala.collection.Seq) JavaConversions.asScalaBuffer(pars), scala.reflect.ClassTag$.MODULE$.apply(List.class));
 
             tupleID += sampleSize;
             result.addAll(((List<Type>[]) samples)[0]);

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/platform/SparkPlatform.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/platform/SparkPlatform.java
@@ -123,7 +123,7 @@ public class SparkPlatform extends Platform {
         final JavaSparkContext sparkContext = this.sparkContextReference.get();
 
         // Set up the JAR files.
-        sparkContext.clearJars();
+        //sparkContext.clearJars();
         if (!sparkContext.isLocal()) {
             // Add Rheem JAR files.
             this.registerJarIfNotNull(ReflectionUtils.getDeclaringJar(SparkPlatform.class)); // rheem-spark

--- a/rheem-platforms/rheem-sqlite3/pom.xml
+++ b/rheem-platforms/rheem-sqlite3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>rheem-platforms</artifactId>
         <groupId>org.qcri.rheem</groupId>
-        <version>0.3.1-SNAPSHOT</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,17 +15,17 @@
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-core</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-basic</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-jdbc-template</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.xerial</groupId>

--- a/rheem-profiler/pom.xml
+++ b/rheem-profiler/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>rheem</artifactId>
         <groupId>org.qcri.rheem</groupId>
-        <version>0.3.1-SNAPSHOT</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -20,27 +20,27 @@
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-spark_2.11</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-java</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-graphchi_2.11</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-postgres</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-sqlite3</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>

--- a/rheem-profiler/src/main/java/org/qcri/rheem/profiler/spark/SparkOperatorProfiler.java
+++ b/rheem-profiler/src/main/java/org/qcri/rheem/profiler/spark/SparkOperatorProfiler.java
@@ -158,7 +158,7 @@ public abstract class SparkOperatorProfiler {
                     for (int i = 0; i < batchSize; i++) {
                         list.add(supplier.get());
                     }
-                    return list;
+                    return list.iterator();
                 });
         // Shuffle and cache the RDD.
         final JavaRDD<T> cachedInputRdd = this.partition(finalInputRdd).cache();

--- a/rheem-tests/pom.xml
+++ b/rheem-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>rheem</artifactId>
         <groupId>org.qcri.rheem</groupId>
-        <version>0.3.1-SNAPSHOT</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -14,43 +14,43 @@
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-core</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-basic</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-java</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-spark_2.11</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-sqlite3</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-postgres</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-graphchi_2.11</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -61,13 +61,13 @@
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-api_2.11</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.qcri.rheem</groupId>
             <artifactId>rheem-iejoin_2.11</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
 
         <!-- Spark is a provided dependency and thus not transitively injected via rheem-spark. -->


### PR DESCRIPTION
At the spark summit 2017, we learned that 80% of spark users are on spark 2, so it makes sense to make the default support for rheem on spark 2.x. We plan to maintain a separate branch for 1.6.x. But from now on, the master branch will be supporting spark 2.x. Note that this PR contains breaking changes.